### PR TITLE
fix: point to correct paths in readthedocs build file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,30 +2,23 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
   jobs:
-    pre_install:
-      - python3 .sphinx/build_requirements.py
+    post_checkout:
       - git fetch --unshallow || true
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   builder: dirhtml
-  configuration: conf.py
+  configuration: docs/conf.py
   fail_on_warning: true
 
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-formats:
-   - pdf
-
-# Optionally declare the Python requirements required to build your docs
+# Optionally declare the Python requirements for building your docs
 python:
-   install:
-   - requirements: .sphinx/requirements.txt
+  install:
+    - requirements: docs/.sphinx/requirements.txt


### PR DESCRIPTION
# Description

Readthedocs can't currently build the project because we are pointing to `sphinx/build_requirements.py` which does not exist. Here we copy the content from the docs for charmed aether sd-core and leverage the right docs directory (`/docs`).

![image](https://github.com/user-attachments/assets/14561fc5-7207-4519-8e67-faacd922e9e8)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
