### PR TITLE
chore: link to Canonical style guide

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@ Please include a summary of the change. Please also include relevant motivation 
 
 # Checklist:
 
-- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
+- [ ] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
 - [ ] I have performed a self-review of my own code
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that validate the behaviour of the software

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # Contributing
 
+## Style Guide
+
+Please follow the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en).
+
 ## Build and test the documentation
 
 ```bash


### PR DESCRIPTION
# Description

Here we link to Canonical Documentation style guide which should be followed for all documentation.

## Reference
- https://docs.ubuntu.com/styleguide/en

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
