### PR TITLE
fix: Fixes the source url of the COS module

### DIFF
--- a/docs/how-to/integrate_oai_ran_with_observability.md
+++ b/docs/how-to/integrate_oai_ran_with_observability.md
@@ -19,7 +19,7 @@ Update your solution Terraform module (here it's named `main.tf`):
 ```console
 cat << EOF > main.tf
 module "cos" {
-  source                   = git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite
+  source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
   model_name               = "cos-lite"
   deploy_cos_configuration = true
   cos_configuration_config = {


### PR DESCRIPTION
# Description

Adds missing double quotes around the COS URL.

# Checklist:

- [x] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
