### PR TITLE
fix: Update documentation to follow CC006

### DIFF
--- a/docs/how-to/deploy_oai_ran.md
+++ b/docs/how-to/deploy_oai_ran.md
@@ -15,7 +15,7 @@ resource "juju_model" "oai-ran" {
 module "cu" {
   source = "git::https://github.com/canonical/oai-ran-cu-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
+  model      = juju_model.oai-ran.name
   config     = {
     "n3-interface-name": "ran"
   }
@@ -24,7 +24,7 @@ module "cu" {
 module "du" {
   source = "git::https://github.com/canonical/oai-ran-du-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
+  model      = juju_model.oai-ran.name
   config     = {
     "simulation-mode": false,
     "use-three-quarter-sampling": true

--- a/docs/how-to/integrate_oai_ran_with_observability.md
+++ b/docs/how-to/integrate_oai_ran_with_observability.md
@@ -17,7 +17,7 @@ Update your solution Terraform module (here it's named `main.tf`):
 cat << EOF > main.tf
 module "cos" {
   source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
-  model_name               = "cos-lite"
+  model                    = "cos-lite"
   deploy_cos_configuration = true
   cos_configuration_config = {
     git_repo                = "https://github.com/canonical/sdcore-cos-configuration"
@@ -83,13 +83,13 @@ resource "juju_model" "ran" {
 
 module "oai-ran" {
   source                   = "git::https://github.com/canonical/terraform-juju-oai-ran-k8s//modules/oai-ran-k8s"
-  model_name               = juju_model.ran.name
+  model                    = juju_model.ran.name
   create_model             = false
 }
 
 module "cos" {
   source                   = "git::https://github.com/canonical/terraform-juju-sdcore//modules/external/cos-lite"
-  model_name               = "cos-lite"
+  model                    = "cos-lite"
   deploy_cos_configuration = true
   cos_configuration_config = {
     git_repo                = "https://github.com/canonical/sdcore-cos-configuration"

--- a/docs/how-to/integrate_oai_ran_with_ue_simulator.md
+++ b/docs/how-to/integrate_oai_ran_with_ue_simulator.md
@@ -14,8 +14,8 @@ To enable the DU to run in simulation mode, set the `simulation-mode` configurat
 module "du" {
   source = "git::https://github.com/canonical/oai-ran-du-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
-  config     = {
+  model  = juju_model.oai-ran.name
+  config = {
     "simulation-mode": true
     "use-three-quarter-sampling" = "true"
   }
@@ -31,7 +31,7 @@ cat << EOF >> ue.tf
 module "ue" {
   source = "git::https://github.com/canonical/oai-ran-ue-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
+  model  = juju_model.oai-ran.name
 }
 
 resource "juju_integration" "ue-du" {

--- a/examples/terraform/getting_started/ran.tf
+++ b/examples/terraform/getting_started/ran.tf
@@ -8,8 +8,8 @@ resource "juju_model" "oai-ran" {
 module "cu" {
   source = "git::https://github.com/canonical/oai-ran-cu-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
-  config     = {
+  model  = juju_model.oai-ran.name
+  config = {
     "n3-interface-name": "ran"
   }
 }
@@ -17,8 +17,8 @@ module "cu" {
 module "du" {
   source = "git::https://github.com/canonical/oai-ran-du-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
-  config     = {
+  model  = juju_model.oai-ran.name
+  config = {
     "simulation-mode": true
   }
 }
@@ -60,7 +60,7 @@ resource "juju_integration" "du-cu" {
 module "ue" {
   source = "git::https://github.com/canonical/oai-ran-ue-k8s-operator//terraform"
 
-  model_name = juju_model.oai-ran.name
+  model = juju_model.oai-ran.name
 }
 
 resource "juju_integration" "ue-du" {


### PR DESCRIPTION
# Description

Fixes the documentation to follow CC006. This brings the documentation in line with the modules that have already been updated.

Depends on https://github.com/canonical/oai-ran-ue-k8s-operator/pull/49 to be merged first.

# Checklist:

- [x] Documentation follows the [Canonical Documentation Style Guide](https://docs.ubuntu.com/styleguide/en)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
